### PR TITLE
Failing unit test for quoted fields

### DIFF
--- a/test/csv.js
+++ b/test/csv.js
@@ -245,7 +245,6 @@ describe('CSV', function () {
       }
     );
 
-
     describe('#1 parse()', function () {
         it('should', function() {
             var obj = CSV.parse('a,b,c\nd,e,f\ng,h,i');
@@ -256,6 +255,16 @@ describe('CSV', function () {
         );
       }
     );
+
+    describe('parse', function () {
+      it('should handle escaped quotes in a cell', function () {
+        var data = 'a,b,c,1,"hello ""world""",12,14'
+        var cols = CSV.parse(data)[0]
+        cols.length.should.equal(7)
+        var expected = ['a','b','c','1','hello, "world"', '12', '14']
+        JSON.stringify(cols).should.equal(JSON.stringify(expected))
+      })
+    })
 
     describe('#1 detect()', function () {
         it('should', function() {


### PR DESCRIPTION
Found this while trying to write a tiny csv script. Ended up using another csv module, but thought I'd help out by contributing a failing unit test so it can either be fixed or listed as a known issue.

The following valid csv row is not being parsed correctly:

```
a,b,c,1,"hello ""world""",12,14
```
