### PR TITLE
old browser compatibility

### DIFF
--- a/lib/csv.js
+++ b/lib/csv.js
@@ -120,7 +120,7 @@ exports.read = function (input, sep, callback) {
       sepx = new RegExp('[^\\s' + sep + ']+.');
 
   function trim (string) {
-    return string.replace(/^[ \t]+|[ \t]+$/g, '');
+    return string.replace(/(^\s*)|(\s*$)/g, '');
   }
 
     //console.log('input:', input);


### PR DESCRIPTION
While recently using your library in a project with browserify, the `.trim()` method prevented it from working in IE7.
I replaced it with a regex.
