### PR TITLE
Add two tests: quote in simple value.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,3 +1,4 @@
+/*jshint node:true,laxcomma:true*/
 'use strict';
 
 /*
@@ -42,7 +43,7 @@ function Parser(input, comma) {
 Parser.prototype.File = function () {
   var files = [], row, eof;
   while (1) {
-    var tempointer = this.pointer
+    var tempointer = this.pointer;
     row = this.Row();
     if (row.length > 0) {
       this.linePointer = tempointer;
@@ -65,7 +66,7 @@ Parser.prototype.File = function () {
     }
   }
   return files;
-}
+};
 
 Parser.prototype.Row = function () {
   var value, comma, linebreak, eof, row = [];
@@ -91,7 +92,7 @@ Parser.prototype.Row = function () {
       return row;
     }
   }
-}
+};
 Parser.prototype.Value = function () {
   var simplevalue, quotedvalue, residue;
 
@@ -109,13 +110,13 @@ Parser.prototype.Value = function () {
     this.Residue();
     return value;
   }
-}
+};
 Parser.prototype.Comma = function () {
   if (this.input.slice(this.pointer, this.pointer + this.comma.length) === this.comma) {
     this.pointer += this.comma.length;
     return this.comma;
   }
-}
+};
 Parser.prototype.LineBreak = function () {
   if (this.input.slice(this.pointer, this.pointer + 2) === '\r\n') {
     this.pointer += 2;
@@ -129,9 +130,9 @@ Parser.prototype.LineBreak = function () {
     this.pointer += 1;
     return '\r';
   }
-}
+};
 Parser.prototype.SimpleValue = function () {
-  var value = '', index = this.input.slice(this.pointer).search(new RegExp('[' + this.comma + '\r\n\"]'))
+  var value = '', index = this.input.slice(this.pointer).search(new RegExp('[' + this.comma + '\r\n\"]'));
   if (index === -1) {
     value = this.input.slice(this.pointer);
   }
@@ -143,7 +144,7 @@ Parser.prototype.SimpleValue = function () {
   }
   this.pointer += value.length;
   return value;
-}
+};
 Parser.prototype.QuotedValue = function () {
   if (this.input.charAt(this.pointer) === '"') {
     var searchIndex, index = 1;
@@ -163,10 +164,10 @@ Parser.prototype.QuotedValue = function () {
       }
     }
   }
-}
+};
 Parser.prototype.EOF = function () {
-  return (this.pointer >= this.input.length)
-}
+  return (this.pointer >= this.input.length);
+};
 Parser.prototype.Residue = function () {
   var value = ''
     , chars = ' \f\v\u00a0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000';
@@ -174,7 +175,7 @@ Parser.prototype.Residue = function () {
   if (this.comma !== "\t") {
     chars += "\t";
   }
-  var index = this.input.slice(this.pointer).search(new RegExp('[^' + chars + ']'))
+  var index = this.input.slice(this.pointer).search(new RegExp('[^' + chars + ']'));
   if (index === -1) {
     value = this.input.slice(this.pointer);
   }
@@ -186,7 +187,7 @@ Parser.prototype.Residue = function () {
   }
   this.pointer += value.length;
   return value;
-}
+};
 
 module.exports = Parser;
 

--- a/test/csv.js
+++ b/test/csv.js
@@ -1,3 +1,5 @@
+/*jshint node:true,laxcomma:true*/
+/*global describe,it */
 'use strict';
 var should = require('should')
 , CSV = require('../lib/csv.js');
@@ -39,7 +41,7 @@ describe('CSV', function () {
     describe('#5 stringify()', function () {
         it('should', function() {
             var str = CSV.stringify();
-            str.should.equal('\r\n');;
+            str.should.equal('\r\n');
           }
         );
       }
@@ -87,7 +89,7 @@ describe('CSV', function () {
     describe('#11 stringify()', function () {
         it('should', function() {
             var str = CSV.stringify({a:1,b:null});
-            str.should.equal('1,\r\n');;
+            str.should.equal('1,\r\n');
           }
         );
       }
@@ -271,12 +273,18 @@ describe('CSV', function () {
         );
       }
     );
+    describe('#13 fetch()', function () {
+      it('should get simple fields containing double quotes', function () {
+        var obj = CSV.fetch('a,this "should" work,b');
+        obj.should.eql(['a','this "should" work','b']);
+      });
+    });
     describe('#1 forEach()', function () {
         it('should', function() {
             var i = 0;
             CSV.forEach('a,b,c\nd,e,f\ng,h,i', function(row, index) {
                 index.should.equal(i++);
-                if (index == 0) {
+                if (index === 0) {
                   row.should.eql(['a','b','c']);
                 }
                 else if (index == 1) {

--- a/test/tsv.js
+++ b/test/tsv.js
@@ -157,6 +157,12 @@ describe('TSV', function () {
         );
       }
     );
+    describe('#13 fetch()', function () {
+      it('should get simple fields containing double quotes', function () {
+        var obj = CSV.fetch('a\tthis "should" work\tb', "\t");
+        obj.should.eql(['a','this "should" work','b']);
+      });
+    });
     /*
     describe('#1 forEach()', function () {
         it('should', function() {


### PR DESCRIPTION
I have a TSV file, generated from another site, which has non quote-delimited fields containing quotes.
These rows suffer from a bad parsing.

Ex:
```
field1\tfield2 "subfield2" blah\tfield3
```

should yield

```javascript
['field1','field2 "subfield2" blah','field3']
```

but returns

```javascript
[ 'field1' ]
[]
[ 'blah', 'field3' ]
```

The two added tests fail. Sorry, I did not find any simple way to fix this.

> Plus, some JSHint.
